### PR TITLE
Go 1.19

### DIFF
--- a/errcheck/Dockerfile
+++ b/errcheck/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.17
+FROM golang:1.19
 
-RUN go get github.com/kisielk/errcheck
+RUN go install github.com/kisielk/errcheck@latest
 
 COPY errcheck.sh /
 ENTRYPOINT ["/errcheck.sh"]

--- a/fmt/Dockerfile
+++ b/fmt/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.19
 
 COPY fmt.sh /
 ENTRYPOINT ["/fmt.sh"]

--- a/sec/Dockerfile
+++ b/sec/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.17
+FROM golang:1.19
 
-RUN go get github.com/securego/gosec/cmd/gosec
+RUN go install github.com/securego/gosec/v2/cmd/gosec@latest
 
 COPY sec.sh /
 ENTRYPOINT ["/sec.sh"]

--- a/vet/Dockerfile
+++ b/vet/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.17
 
-RUN go get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
+RUN go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest
 
 COPY vet.sh /
 ENTRYPOINT ["/vet.sh"]


### PR DESCRIPTION
Update go to 1.19 and change the installation type to `go install` from `go get`.