### PR TITLE
Use a fixed version of github.com/securego/gosec lib

### DIFF
--- a/sec/Dockerfile
+++ b/sec/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.20
 
-RUN go install github.com/securego/gosec/v2/cmd/gosec@latest
+RUN go install github.com/securego/gosec/v2/cmd/gosec@v2.19.0
 
 COPY sec.sh /
 ENTRYPOINT ["/sec.sh"]


### PR DESCRIPTION
This should fix the error found at https://github.com/aminueza/terraform-provider-minio/actions/runs/9190808963/job/25294271689?pr=563

<img width="738" alt="image" src="https://github.com/aminueza/go-github-action/assets/418083/f6dd767a-9f09-4739-9096-06122e11f6c3">
